### PR TITLE
feat(ui): bold crimson terminal redesign with dark/light mode

### DIFF
--- a/.github/workflows/sync-hweb.yml
+++ b/.github/workflows/sync-hweb.yml
@@ -39,7 +39,7 @@ jobs:
           repository: engels74/repo-patches
           token: ${{ secrets.GH_PAT }}
           path: patches
-          ref: feat/ui-crimson-redesign  # TEMP: testing UI redesign branch
+          ref: main
 
       # ============================================================
       # STEP 3: Configure Git

--- a/.github/workflows/sync-hweb.yml
+++ b/.github/workflows/sync-hweb.yml
@@ -39,7 +39,7 @@ jobs:
           repository: engels74/repo-patches
           token: ${{ secrets.GH_PAT }}
           path: patches
-          ref: main
+          ref: feat/ui-crimson-redesign  # TEMP: testing UI redesign branch
 
       # ============================================================
       # STEP 3: Configure Git

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,64 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This repository (`repo-patches`) contains GitHub Actions workflows and customization content for syncing engels74's Docker container repositories and documentation website from upstream [hotio](https://github.com/hotio) sources.
+
+**Purpose:** Maintain branded forks of hotio Docker images and documentation while staying in sync with upstream changes.
+
+## Workflows
+
+### base-image.yml
+Syncs `engels74/base-image` from `hotio/base`. Processes branches `alpinevpn` and `noblevpn`:
+1. Hard resets to upstream
+2. Patches CI workflow to use engels74's build workflow
+3. Patches s6 init script with engels74 branding (figlet, URLs)
+4. Overwrites README.md
+
+**Trigger:** Manual dispatch only
+
+### sync-hweb.yml
+Syncs `engels74/website` from `hotio/website`:
+1. Hard resets to upstream
+2. Deletes unwanted container docs (keeps only 8 containers)
+3. Removes scripts and guides sections
+4. Copies custom mkdocs.yml, homepage, FAQ, and container docs from `hweb-content/`
+5. Copies custom assets (logo, stylesheets)
+6. Cleans up unused images
+
+**Trigger:** Manual dispatch (supports dry-run mode)
+
+## Content Structure
+
+```
+hweb-content/
+├── config/mkdocs.yml           # Full site configuration
+├── docs/
+│   ├── index.md                # Homepage
+│   ├── faq.md                  # Redirects to hotio.dev
+│   ├── CNAME                   # engels74.net
+│   ├── overrides/main.html     # Theme overrides
+│   └── containers/             # 8 container docs + tags JSON
+└── assets/
+    ├── stylesheets/extra-custom.css
+    └── img/engels74.svg
+```
+
+## Containers Kept
+
+base-image, caddy, obzorarr, overseerr-anime, qbittorrent, qflood, sabnzbd, tgraph-bot
+
+## Adding a New Container
+
+1. Create `hweb-content/docs/containers/{name}.md` with pre-rendered tag table
+2. Add to `CONTAINERS_TO_KEEP` and `TAGS_JSON_TO_KEEP` arrays in sync-hweb.yml
+3. Add to `REQUIRED_FILES` verification array
+4. Add to `CONTAINERS` copy array
+5. Add logo to `KEEP_LOGOS` if needed
+6. Add to mkdocs.yml navigation
+
+## Requirements
+
+**Secret:** `GH_PAT` - Personal Access Token with `repo` scope for cross-repository operations.

--- a/README.md
+++ b/README.md
@@ -1,213 +1,70 @@
-# engels74-repo-patches
+# repo-patches
 
-This repository contains GitHub Actions workflows and modular content for syncing and customizing engels74's Docker container repositories and documentation websites from upstream hotio sources.
+GitHub Actions workflows and modular content for syncing engels74's Docker container repositories and documentation website from upstream [hotio](https://github.com/hotio) sources.
 
 ## Workflows
 
-### `base-image.yml`
-Syncs the `engels74/base-image` repository with upstream `hotio/base`, applying branding modifications.
+| Workflow | Target Repository | Upstream Source | Trigger |
+|----------|-------------------|-----------------|---------|
+| `base-image.yml` | `engels74/base-image` | `hotio/base` | Manual dispatch |
+| `sync-hweb.yml` | `engels74/website` | `hotio/website` | Manual dispatch (with dry-run option) |
 
-### `sync-hweb.yml`
-Syncs the `engels74/website` documentation website with upstream `hotio/website`, applying comprehensive customizations including:
-- Custom navigation structure
-- Container documentation for engels74's forks
-- Branding and URL replacements
-- Removal of unused content
+Both workflows apply engels74 branding and customizations during sync.
 
-**Triggers:**
-- Manual dispatch (with optional dry-run mode)
-- Weekly schedule (Sundays at 00:00 UTC)
-
-## Modular Content Structure
+## Content Structure
 
 ```
 hweb-content/
 ├── config/
-│   └── mkdocs.yml              # Custom MkDocs configuration
+│   └── mkdocs.yml                  # Site configuration (navigation, branding)
 ├── docs/
-│   ├── index.md                # Custom homepage
-│   ├── faq.md                  # FAQ with redirect to hotio.dev
-│   ├── CNAME                   # Domain configuration
+│   ├── index.md                    # Homepage
+│   ├── faq.md                      # FAQ (redirects to hotio.dev)
+│   ├── CNAME                       # Domain: engels74.net
 │   ├── overrides/
-│   │   └── main.html           # Theme overrides (favicon, fonts)
-│   └── containers/             # Container documentation
-│       ├── base-image.md
-│       ├── base-image-tags.json
-│       ├── caddy.md
-│       ├── caddy-tags.json
-│       ├── obzorarr.md
-│       ├── obzorarr-tags.json
-│       ├── overseerr-anime.md
-│       ├── overseerr-anime-tags.json
-│       ├── qbittorrent.md
-│       ├── qbittorrent-tags.json
-│       ├── qflood.md
-│       ├── qflood-tags.json
-│       ├── sabnzbd.md
-│       ├── sabnzbd-tags.json
-│       ├── tgraph-bot.md
-│       └── tgraph-bot-tags.json
+│   │   └── main.html               # Theme overrides
+│   └── containers/                 # Documentation and tag metadata
+│       ├── base-image.md / .json
+│       ├── caddy.md / .json
+│       ├── obzorarr.md / .json
+│       ├── overseerr-anime.md / .json
+│       ├── qbittorrent.md / .json
+│       ├── qflood.md / .json
+│       ├── sabnzbd.md / .json
+│       └── tgraph-bot.md / .json
 └── assets/
+    ├── stylesheets/
+    │   └── extra-custom.css        # Custom theme styles
     └── img/
-        ├── engels74.svg        # Custom branding logo
-        └── image-logos/        # Container logos
+        ├── engels74.svg            # Site logo
+        └── image-logos/            # Container logos
 ```
 
----
+## Containers
 
-# Modularization Analysis
+| Container | Description |
+|-----------|-------------|
+| base-image | Alpine-based foundation image with VPN and s6-overlay support |
+| caddy | Caddy 2 web server with custom modules |
+| obzorarr | Original container (not in upstream) |
+| overseerr-anime | Overseerr fork with anime instance support |
+| qbittorrent | qBittorrent with libtorrent v2 |
+| qflood | qBittorrent with Flood web UI |
+| sabnzbd | SABnzbd usenet client |
+| tgraph-bot | Original container (not in upstream) |
 
-## Overview
+## Sync Behavior
 
-This document explains what content is modularized in `hweb-content/` and why each decision was made.
+**Replaced:** MkDocs configuration, homepage, FAQ, all container documentation, CNAME, branding assets
 
-## Content Stored in repo-patches (Source of Truth)
+**Preserved from upstream:** VPN include snippets, base stylesheets, JavaScript utilities, affiliate banners, container logos for kept images
 
-### 1. Container Documentation (8 files)
+**Removed:** Container docs not in the keep list, scripts section, guides section, unused images
 
-**Location:** `hweb-content/docs/containers/`
+## Requirements
 
-| File | Reason for Modularization |
-|------|--------------------------|
-| `base-image.md` | Custom version with engels74 branding and ghcr.io references |
-| `caddy.md` | Custom Caddy 2 configuration with engels74-specific modules |
-| `obzorarr.md` | Engels74-unique container (not in hotio upstream) |
-| `overseerr-anime.md` | Fork of seerr with anime-specific customizations |
-| `qbittorrent.md` | Custom qBittorrent with libtorrent v2 |
-| `qflood.md` | Custom qBittorrent+Flood combo (different from hotio/rflood) |
-| `sabnzbd.md` | Custom SABnzbd configuration |
-| `tgraph-bot.md` | Engels74-unique container (not in hotio upstream) |
+**Secret:** `GH_PAT` - Personal Access Token with `repo` scope
 
-**Why modularize?** These files contain:
-- `ghcr.io/engels74/` container references instead of `ghcr.io/hotio/`
-- Custom descriptions and usage notes
-- Engels74-specific configuration examples
-- Containers unique to engels74 (obzorarr, tgraph-bot)
+## License
 
-### 2. Homepage (`index.md`)
-
-**Location:** `hweb-content/docs/index.md`
-
-**Why modularize?** Contains:
-- Custom welcome message explaining this is a fork
-- engels74-specific support information
-- References to engels74's container selection
-
-### 3. FAQ Page (`faq.md`)
-
-**Location:** `hweb-content/docs/faq.md`
-
-**Why modularize?** Implements:
-- JavaScript confirmation dialog before redirecting to hotio.dev/faq
-- Fallback content for users with JavaScript disabled
-- Explanation of why redirect is used
-
-### 4. MkDocs Configuration (`mkdocs.yml`)
-
-**Location:** `hweb-content/config/mkdocs.yml`
-
-**Why modularize?** Contains:
-- `site_name: engels74.net` (not `hotio.dev`)
-- `site_url: https://engels74.net`
-- `repo_url: https://github.com/engels74`
-- Custom navigation with only 8 containers
-- No Scripts section
-- No Guides section
-- Logo reference to `img/engels74.svg`
-
-### 5. Domain Configuration (`CNAME`)
-
-**Location:** `hweb-content/docs/CNAME`
-
-**Why modularize?** Contains `engels74.net` for GitHub Pages domain routing.
-
-### 6. Branding Logo (`engels74.svg`)
-
-**Location:** `hweb-content/assets/img/engels74.svg`
-
-**Why modularize?** Custom branding logo that replaces `hotio.svg` in the site header.
-
----
-
-## Content NOT Modularized (Synced from Upstream)
-
-### 1. Include Snippets (`includes/`)
-
-| File | Reason to Keep Upstream |
-|------|------------------------|
-| `annotations.md` | VPN environment variable annotations - generic, works for all containers |
-| `wireguard.md` | VPN configuration examples - generic across all containers |
-
-**Why not modularize?** These snippets use `--8<--` syntax and work identically for both hotio and engels74 containers.
-
-### 2. Stylesheets (`docs/stylesheets/extra-13.css`)
-
-**Why not modularize?** The "hotio" color scheme is shared. Engels74 uses the same dark theme with orange accents.
-
-### 3. JavaScript (`docs/javascripts/tablesort.js`, `tagcopy.js`)
-
-**Why not modularize?** These scripts handle table column sorting and click-to-copy functionality for tags. They work with any pre-rendered HTML tags table.
-
-### 4. VPN Banner Images
-
-**Why not modularize?** Affiliate banners for ProtonVPN and PIA are shared with hotio. Same affiliate links benefit both.
-
----
-
-## Workflow Behavior
-
-### What Gets Deleted During Sync
-
-1. **Container Docs** not in the keep list:
-   - Uses inverse logic: only 8 containers are kept (base-image, caddy, obzorarr, overseerr-anime, qbittorrent, qflood, sabnzbd, tgraph-bot)
-   - All other container docs from upstream are automatically deleted
-   - This handles hotio adding/removing containers without workflow changes
-
-2. **Scripts Folder** (`docs/scripts/`):
-   - sysinfo.md, pullio.md, arr-discord-notifier.md
-
-3. **Guides Folder** (`docs/guides/`):
-   - torguard.md (and any other guides)
-
-4. **Unused Images**:
-   - Pullio mascot images (17 files)
-   - Script screenshots
-   - Unused container logos (for containers not in engels74's list)
-   - Unused webhook avatars
-
-### What Gets Replaced
-
-1. `mkdocs.yml` - Complete replacement with custom navigation
-2. `docs/index.md` - Custom homepage
-3. `docs/faq.md` - Custom FAQ with redirect
-4. `docs/containers/*.md` - All 8 container docs (pre-rendered HTML tables)
-5. `docs/containers/*-tags.json` - All 8 container tag metadata files
-6. `docs/CNAME` - Domain configuration
-7. `docs/img/engels74.svg` - Custom logo
-8. `overrides/main.html` - Custom favicon and font configuration
-
-### What Gets Preserved from Upstream
-
-1. `includes/annotations.md`, `includes/wireguard.md` - VPN snippets
-2. `docs/stylesheets/extra-13.css` - Theme styles
-3. `docs/javascripts/tablesort.js`, `tagcopy.js` - Table sorting and copy-to-clipboard
-4. VPN affiliate banners
-5. Favicon
-6. Core image logos for kept containers
-
----
-
-## Error Handling
-
-The workflow implements fail-fast behavior:
-
-1. **Pre-flight Check**: Verifies all required source files exist before any modifications
-2. **Explicit File Checks**: Each file operation verifies success
-3. **Post-modification Verification**: Confirms final structure before commit
-4. **Dry-run Mode**: Test changes without pushing
-
----
-
-## Secrets Required
-
-- `GH_PAT`: Personal Access Token with `repo` scope for pushing to `engels74/website`
+AGPL-3.0

--- a/hweb-content/assets/stylesheets/extra-custom.css
+++ b/hweb-content/assets/stylesheets/extra-custom.css
@@ -1,11 +1,1340 @@
-/* Custom styles for engels74.net */
+/* =============================================================================
+   ENGELS74.NET - CRIMSON TERMINAL THEME
+   Bold, distinctive aesthetic with terminal-inspired elements
+   ============================================================================= */
 
-/* Container logo sizing */
+/* =============================================================================
+   1. CSS CUSTOM PROPERTIES
+   ============================================================================= */
+
+:root {
+  /* Light mode - Warm with edge */
+  --e74-bg-primary: #FFFBFA;
+  --e74-bg-surface: #FFFFFF;
+  --e74-bg-surface-alt: #FEF2F2;
+  --e74-border: #FECACA;
+  --e74-border-subtle: #FEE2E2;
+  --e74-text-primary: #1C1917;
+  --e74-text-secondary: #57534E;
+  --e74-text-muted: #78716C;
+  --e74-accent: #E11D48;
+  --e74-accent-hover: #BE123C;
+  --e74-accent-subtle: #FFF1F2;
+  --e74-accent-glow: rgba(225, 29, 72, 0.15);
+  --e74-accent-glow-strong: rgba(225, 29, 72, 0.3);
+
+  /* Typography */
+  --e74-font-display: 'Outfit', -apple-system, BlinkMacSystemFont, sans-serif;
+  --e74-font-body: 'DM Sans', -apple-system, BlinkMacSystemFont, sans-serif;
+  --e74-font-mono: 'JetBrains Mono', 'Fira Code', monospace;
+
+  /* Spacing & Sizing */
+  --e74-radius-sm: 6px;
+  --e74-radius: 12px;
+  --e74-radius-lg: 20px;
+  --e74-shadow-sm: 0 1px 2px rgba(28, 25, 23, 0.06);
+  --e74-shadow: 0 4px 12px rgba(28, 25, 23, 0.08), 0 2px 4px rgba(28, 25, 23, 0.04);
+  --e74-shadow-lg: 0 20px 40px rgba(28, 25, 23, 0.12), 0 8px 16px rgba(28, 25, 23, 0.08);
+  --e74-shadow-glow: 0 0 40px var(--e74-accent-glow), 0 0 80px var(--e74-accent-glow);
+
+  /* Transitions */
+  --e74-transition-fast: 120ms cubic-bezier(0.4, 0, 0.2, 1);
+  --e74-transition: 200ms cubic-bezier(0.4, 0, 0.2, 1);
+  --e74-transition-slow: 400ms cubic-bezier(0.4, 0, 0.2, 1);
+  --e74-transition-bounce: 500ms cubic-bezier(0.34, 1.56, 0.64, 1);
+
+  /* Grain opacity */
+  --e74-grain-opacity: 0.03;
+}
+
+[data-md-color-scheme="slate"] {
+  /* Dark mode - Deep, dramatic, glowing */
+  --e74-bg-primary: #0A0908;
+  --e74-bg-surface: #151311;
+  --e74-bg-surface-alt: #1E1C1A;
+  --e74-border: #2E2A27;
+  --e74-border-subtle: #252220;
+  --e74-text-primary: #FAF9F7;
+  --e74-text-secondary: #B8B2AC;
+  --e74-text-muted: #7A756F;
+  --e74-accent: #FB7185;
+  --e74-accent-hover: #FDA4AF;
+  --e74-accent-subtle: rgba(251, 113, 133, 0.08);
+  --e74-accent-glow: rgba(251, 113, 133, 0.2);
+  --e74-accent-glow-strong: rgba(251, 113, 133, 0.4);
+
+  --e74-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
+  --e74-shadow: 0 4px 12px rgba(0, 0, 0, 0.4), 0 2px 4px rgba(0, 0, 0, 0.3);
+  --e74-shadow-lg: 0 20px 40px rgba(0, 0, 0, 0.5), 0 8px 16px rgba(0, 0, 0, 0.4);
+  --e74-shadow-glow: 0 0 60px var(--e74-accent-glow-strong), 0 0 120px var(--e74-accent-glow);
+
+  --e74-grain-opacity: 0.04;
+}
+
+/* =============================================================================
+   2. GRAIN TEXTURE OVERLAY
+   ============================================================================= */
+
+body::before {
+  content: "";
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 9999;
+  opacity: var(--e74-grain-opacity);
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
+}
+
+/* =============================================================================
+   3. MATERIAL THEME VARIABLE OVERRIDES
+   ============================================================================= */
+
+:root,
+[data-md-color-scheme="default"] {
+  --md-default-bg-color: var(--e74-bg-primary);
+  --md-default-fg-color: var(--e74-text-primary);
+  --md-default-fg-color--light: var(--e74-text-secondary);
+  --md-default-fg-color--lighter: var(--e74-text-muted);
+  --md-default-fg-color--lightest: var(--e74-border);
+  --md-primary-fg-color: var(--e74-accent);
+  --md-primary-fg-color--light: var(--e74-accent-subtle);
+  --md-primary-fg-color--dark: var(--e74-accent-hover);
+  --md-primary-bg-color: var(--e74-bg-surface);
+  --md-primary-bg-color--light: var(--e74-bg-surface-alt);
+  --md-accent-fg-color: var(--e74-accent);
+  --md-accent-fg-color--transparent: var(--e74-accent-glow);
+  --md-accent-bg-color: var(--e74-accent);
+  --md-typeset-a-color: var(--e74-accent);
+  --md-code-bg-color: var(--e74-bg-surface-alt);
+  --md-code-fg-color: var(--e74-text-primary);
+  --md-code-hl-color: var(--e74-accent-subtle);
+  --md-footer-bg-color: var(--e74-bg-surface);
+  --md-footer-bg-color--dark: var(--e74-bg-surface-alt);
+}
+
+[data-md-color-scheme="slate"] {
+  --md-default-bg-color: var(--e74-bg-primary);
+  --md-default-fg-color: var(--e74-text-primary);
+  --md-default-fg-color--light: var(--e74-text-secondary);
+  --md-default-fg-color--lighter: var(--e74-text-muted);
+  --md-default-fg-color--lightest: var(--e74-border);
+  --md-primary-fg-color: var(--e74-accent);
+  --md-primary-fg-color--light: var(--e74-accent-subtle);
+  --md-primary-fg-color--dark: var(--e74-accent-hover);
+  --md-primary-bg-color: var(--e74-bg-surface);
+  --md-primary-bg-color--light: var(--e74-bg-surface-alt);
+  --md-accent-fg-color: var(--e74-accent);
+  --md-accent-fg-color--transparent: var(--e74-accent-glow);
+  --md-accent-bg-color: var(--e74-accent);
+  --md-typeset-a-color: var(--e74-accent);
+  --md-code-bg-color: var(--e74-bg-surface-alt);
+  --md-code-fg-color: var(--e74-text-primary);
+  --md-code-hl-color: var(--e74-accent-subtle);
+  --md-footer-bg-color: var(--e74-bg-surface);
+  --md-footer-bg-color--dark: var(--e74-bg-surface-alt);
+}
+
+/* =============================================================================
+   4. BASE TYPOGRAPHY
+   ============================================================================= */
+
+body {
+  font-family: var(--e74-font-body);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.md-typeset h1,
+.md-typeset h2,
+.md-typeset h3,
+.md-typeset h4,
+.md-typeset h5,
+.md-typeset h6 {
+  font-family: var(--e74-font-display);
+  font-weight: 600;
+  color: var(--e74-text-primary);
+}
+
+.md-typeset h1 {
+  font-weight: 700;
+  letter-spacing: -0.03em;
+}
+
+.md-typeset h2 {
+  letter-spacing: -0.02em;
+}
+
+.md-typeset code,
+.md-typeset pre {
+  font-family: var(--e74-font-mono);
+}
+
+.md-typeset a {
+  color: var(--e74-accent);
+  text-decoration: none;
+  background: linear-gradient(var(--e74-accent), var(--e74-accent)) no-repeat 0 100%;
+  background-size: 0% 2px;
+  transition: background-size var(--e74-transition), color var(--e74-transition-fast);
+}
+
+.md-typeset a:hover {
+  color: var(--e74-accent-hover);
+  background-size: 100% 2px;
+}
+
+/* =============================================================================
+   5. NAVIGATION - GLOWING HEADER
+   ============================================================================= */
+
+.md-header {
+  background: var(--e74-bg-surface);
+  border-bottom: 1px solid var(--e74-border-subtle);
+  box-shadow: var(--e74-shadow-sm);
+  backdrop-filter: blur(12px);
+  background: rgba(255, 251, 250, 0.85);
+}
+
+[data-md-color-scheme="slate"] .md-header {
+  background: rgba(10, 9, 8, 0.85);
+  border-bottom-color: var(--e74-border);
+}
+
+.md-header__title {
+  font-family: var(--e74-font-display);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+/* Navigation tabs with accent underline */
+.md-tabs {
+  background: transparent;
+  border-bottom: 1px solid var(--e74-border-subtle);
+}
+
+.md-tabs__link {
+  font-family: var(--e74-font-display);
+  font-weight: 500;
+  opacity: 0.7;
+  transition: all var(--e74-transition);
+  position: relative;
+}
+
+.md-tabs__link::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 0;
+  height: 2px;
+  background: var(--e74-accent);
+  transition: all var(--e74-transition);
+  transform: translateX(-50%);
+  border-radius: 2px 2px 0 0;
+}
+
+.md-tabs__link:hover {
+  opacity: 1;
+}
+
+.md-tabs__link:hover::after,
+.md-tabs__link--active::after {
+  width: 100%;
+}
+
+.md-tabs__link--active {
+  opacity: 1;
+  color: var(--e74-accent);
+}
+
+/* Sidebar navigation */
+.md-nav__link {
+  font-family: var(--e74-font-body);
+  transition: all var(--e74-transition-fast);
+  border-radius: var(--e74-radius-sm);
+  margin: 2px 0;
+}
+
+.md-nav__link:hover {
+  color: var(--e74-accent);
+  background: var(--e74-accent-subtle);
+  padding-left: 0.5rem;
+}
+
+.md-nav__link--active {
+  color: var(--e74-accent);
+  font-weight: 600;
+  background: var(--e74-accent-subtle);
+}
+
+/* =============================================================================
+   6. CONTENT AREA
+   ============================================================================= */
+
+.md-content {
+  background-color: var(--e74-bg-primary);
+}
+
+/* Code blocks with accent border */
+.md-typeset pre {
+  border-radius: var(--e74-radius);
+  border: 1px solid var(--e74-border-subtle);
+  box-shadow: var(--e74-shadow);
+  position: relative;
+  overflow: hidden;
+}
+
+.md-typeset pre::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 3px;
+  height: 100%;
+  background: linear-gradient(180deg, var(--e74-accent), transparent);
+}
+
+.md-typeset code {
+  border-radius: var(--e74-radius-sm);
+  padding: 0.15em 0.4em;
+  background-color: var(--e74-bg-surface-alt);
+  font-size: 0.875em;
+}
+
+.md-typeset a code {
+  color: var(--e74-accent);
+}
+
+/* =============================================================================
+   7. ADMONITIONS - DRAMATIC STYLING
+   ============================================================================= */
+
+.md-typeset .admonition,
+.md-typeset details {
+  border-radius: var(--e74-radius);
+  border: 1px solid var(--e74-border-subtle);
+  box-shadow: var(--e74-shadow);
+  font-size: 0.9rem;
+  overflow: hidden;
+}
+
+.md-typeset .admonition-title,
+.md-typeset summary {
+  font-family: var(--e74-font-display);
+  font-weight: 600;
+}
+
+/* Question admonition - accent glow */
+.md-typeset .admonition.question {
+  border-color: var(--e74-accent);
+  border-left-width: 3px;
+  background: linear-gradient(135deg, var(--e74-accent-subtle) 0%, var(--e74-bg-surface) 50%);
+}
+
+.md-typeset .admonition.question > .admonition-title {
+  background: transparent;
+  color: var(--e74-accent);
+}
+
+[data-md-color-scheme="slate"] .md-typeset .admonition.question {
+  box-shadow: var(--e74-shadow), inset 0 0 40px var(--e74-accent-glow);
+}
+
+/* =============================================================================
+   8. TABLES - REFINED WITH HOVER GLOW
+   ============================================================================= */
+
+.md-typeset table:not([class]) {
+  border-radius: var(--e74-radius);
+  overflow: hidden;
+  border: 1px solid var(--e74-border);
+  box-shadow: var(--e74-shadow);
+  font-size: 0.9rem;
+}
+
+.md-typeset table:not([class]) th {
+  background: linear-gradient(180deg, var(--e74-bg-surface-alt), var(--e74-bg-surface));
+  font-family: var(--e74-font-display);
+  font-weight: 600;
+  color: var(--e74-text-primary);
+  border-bottom: 2px solid var(--e74-border);
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+}
+
+.md-typeset table:not([class]) td {
+  border-bottom: 1px solid var(--e74-border-subtle);
+  transition: background var(--e74-transition-fast);
+}
+
+.md-typeset table:not([class]) tr:last-child td {
+  border-bottom: none;
+}
+
+.md-typeset table:not([class]) tbody tr {
+  transition: all var(--e74-transition-fast);
+}
+
+.md-typeset table:not([class]) tbody tr:hover {
+  background: var(--e74-accent-subtle);
+}
+
+[data-md-color-scheme="slate"] .md-typeset table:not([class]) tbody tr:hover {
+  box-shadow: inset 0 0 30px var(--e74-accent-glow);
+}
+
+/* Tags table */
+#tags-table {
+  margin: 1.5rem 0;
+}
+
+#tags-table table {
+  width: 100%;
+  border-radius: var(--e74-radius);
+  overflow: hidden;
+  border: 1px solid var(--e74-border);
+  box-shadow: var(--e74-shadow);
+  border-collapse: separate;
+  border-spacing: 0;
+}
+
+#tags-table th {
+  background: linear-gradient(180deg, var(--e74-bg-surface-alt), var(--e74-bg-surface));
+  font-family: var(--e74-font-display);
+  font-weight: 600;
+  color: var(--e74-text-primary);
+  padding: 0.875rem 1rem;
+  text-align: left;
+  border-bottom: 2px solid var(--e74-border);
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+}
+
+#tags-table td {
+  padding: 0.875rem 1rem;
+  border-bottom: 1px solid var(--e74-border-subtle);
+  vertical-align: middle;
+}
+
+#tags-table tr:last-child td {
+  border-bottom: none;
+}
+
+#tags-table tbody tr {
+  transition: all var(--e74-transition-fast);
+}
+
+#tags-table tbody tr:hover {
+  background: var(--e74-accent-subtle);
+}
+
+[data-md-color-scheme="slate"] #tags-table tbody tr:hover {
+  box-shadow: inset 0 0 40px var(--e74-accent-glow);
+}
+
+/* Tag decorations - terminal style */
+.tag-decoration,
+.tag-decoration-latest {
+  display: inline-block;
+  padding: 0.3rem 0.7rem;
+  border-radius: var(--e74-radius-sm);
+  font-family: var(--e74-font-mono);
+  font-size: 0.8rem;
+  font-weight: 500;
+  margin: 0.15rem 0.25rem 0.15rem 0;
+  transition: all var(--e74-transition);
+  position: relative;
+}
+
+.tag-decoration {
+  background: var(--e74-bg-surface-alt);
+  color: var(--e74-accent);
+  cursor: pointer;
+  border: 1px solid var(--e74-border-subtle);
+}
+
+.tag-decoration::before {
+  content: "$ ";
+  opacity: 0.5;
+}
+
+.tag-decoration:hover {
+  background: var(--e74-accent);
+  color: white;
+  border-color: var(--e74-accent);
+  transform: translateY(-2px) scale(1.02);
+  box-shadow: var(--e74-shadow), 0 0 20px var(--e74-accent-glow);
+}
+
+.tag-decoration-latest {
+  background: linear-gradient(135deg, var(--e74-accent), #F43F5E);
+  color: white;
+  font-weight: 600;
+  border: none;
+  box-shadow: 0 2px 8px var(--e74-accent-glow);
+}
+
+.tag-decoration-latest::before {
+  content: "★ ";
+}
+
+/* Info icon in tags table */
+#tags-table .twemoji {
+  vertical-align: middle;
+  margin-left: 0.5rem;
+  opacity: 0.5;
+}
+
+#tags-table .twemoji svg {
+  width: 0.9rem;
+  height: 0.9rem;
+  fill: var(--e74-text-muted);
+}
+
+/* =============================================================================
+   9. BUTTONS - BOLD WITH GLOW
+   ============================================================================= */
+
+.md-button {
+  font-family: var(--e74-font-display);
+  font-weight: 600;
+  border-radius: var(--e74-radius-sm);
+  padding: 0.7rem 1.4rem;
+  transition: all var(--e74-transition);
+  position: relative;
+  overflow: hidden;
+}
+
+.md-button::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: -100%;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(90deg, transparent, rgba(255,255,255,0.2), transparent);
+  transition: left var(--e74-transition-slow);
+}
+
+.md-button:hover::before {
+  left: 100%;
+}
+
+.md-button:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--e74-shadow-lg);
+}
+
+.md-button--primary {
+  background: linear-gradient(135deg, var(--e74-accent), #F43F5E);
+  border: none;
+  color: white;
+  box-shadow: 0 4px 15px var(--e74-accent-glow);
+}
+
+.md-button--primary:hover {
+  box-shadow: var(--e74-shadow-glow);
+}
+
+/* =============================================================================
+   10. CONTAINER PAGE SPECIFIC
+   ============================================================================= */
+
+/* Header links - chip style with glow */
+.header-links {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem 1rem;
+  margin-right: 0.5rem;
+  margin-bottom: 0.5rem;
+  background: var(--e74-bg-surface);
+  border: 1px solid var(--e74-border-subtle);
+  border-radius: 50px;
+  font-family: var(--e74-font-mono);
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--e74-text-secondary);
+  text-decoration: none;
+  transition: all var(--e74-transition);
+}
+
+.header-links:hover {
+  background: var(--e74-accent);
+  border-color: var(--e74-accent);
+  color: white;
+  text-decoration: none;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 20px var(--e74-accent-glow);
+}
+
+[data-md-color-scheme="slate"] .header-links:hover {
+  box-shadow: var(--e74-shadow-glow);
+}
+
+/* Container logo with glow */
 .image-logo {
-  margin-bottom: 1rem;
+  margin: 2rem 0;
+  position: relative;
 }
 
 .image-logo img {
-  max-height: 64px;
+  max-height: 120px;
   width: auto;
+  filter: drop-shadow(0 4px 8px rgba(0, 0, 0, 0.1));
+  transition: all var(--e74-transition);
+}
+
+.image-logo:hover img {
+  transform: scale(1.05);
+  filter: drop-shadow(0 8px 20px var(--e74-accent-glow));
+}
+
+[data-md-color-scheme="slate"] .image-logo img {
+  filter: drop-shadow(0 4px 20px rgba(0, 0, 0, 0.4));
+}
+
+[data-md-color-scheme="slate"] .image-logo:hover img {
+  filter: drop-shadow(0 0 30px var(--e74-accent-glow-strong));
+}
+
+/* =============================================================================
+   11. HOMEPAGE HERO - DRAMATIC ASYMMETRIC
+   ============================================================================= */
+
+.e74-hero {
+  position: relative;
+  padding: 4rem 2rem 5rem;
+  margin: -0.8rem -0.8rem 3rem -0.8rem;
+  overflow: hidden;
+  background: var(--e74-bg-surface);
+}
+
+/* Diagonal accent stripe */
+.e74-hero::before {
+  content: "";
+  position: absolute;
+  top: -50%;
+  right: -20%;
+  width: 80%;
+  height: 200%;
+  background: linear-gradient(135deg, var(--e74-accent-subtle) 0%, transparent 60%);
+  transform: rotate(-12deg);
+  pointer-events: none;
+}
+
+/* Glowing orb accent */
+.e74-hero::after {
+  content: "";
+  position: absolute;
+  top: 20%;
+  right: 10%;
+  width: 300px;
+  height: 300px;
+  background: radial-gradient(circle, var(--e74-accent-glow) 0%, transparent 70%);
+  pointer-events: none;
+  animation: pulse-glow 4s ease-in-out infinite;
+}
+
+@keyframes pulse-glow {
+  0%, 100% { opacity: 0.5; transform: scale(1); }
+  50% { opacity: 0.8; transform: scale(1.1); }
+}
+
+[data-md-color-scheme="slate"] .e74-hero::after {
+  opacity: 0.6;
+}
+
+.e74-hero h1,
+.e74-hero-title {
+  font-family: var(--e74-font-display) !important;
+  font-size: clamp(2.5rem, 6vw, 4rem) !important;
+  font-weight: 700 !important;
+  background: linear-gradient(135deg, var(--e74-accent) 0%, #F43F5E 50%, #FB923C 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  margin-bottom: 0.5rem !important;
+  line-height: 1.1 !important;
+  letter-spacing: -0.03em !important;
+  position: relative;
+  z-index: 1;
+  animation: fade-in-up 0.6s ease-out;
+}
+
+@keyframes fade-in-up {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.e74-hero-subtitle {
+  font-size: 1.25rem !important;
+  color: var(--e74-text-secondary) !important;
+  font-weight: 500 !important;
+  margin-bottom: 0 !important;
+  position: relative;
+  z-index: 1;
+  animation: fade-in-up 0.6s ease-out 0.1s backwards;
+}
+
+.e74-hero p:not(.e74-hero-subtitle) {
+  color: var(--e74-text-muted);
+  max-width: 550px;
+  line-height: 1.7;
+  position: relative;
+  z-index: 1;
+  animation: fade-in-up 0.6s ease-out 0.2s backwards;
+}
+
+/* Terminal cursor blink */
+.e74-hero-subtitle::after {
+  content: "_";
+  animation: blink 1s step-end infinite;
+  color: var(--e74-accent);
+  font-weight: 400;
+}
+
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0; }
+}
+
+/* =============================================================================
+   12. HOMEPAGE CONTAINER REGISTRY - UNIFIED PANEL
+   ============================================================================= */
+
+.e74-registry {
+  background: var(--e74-bg-surface);
+  border: 1px solid var(--e74-border-subtle);
+  border-radius: var(--e74-radius-lg);
+  padding: 2rem 2.5rem;
+  margin: 2rem 0;
+  position: relative;
+  overflow: hidden;
+  animation: registry-enter 0.6s ease-out backwards;
+  animation-delay: 0.15s;
+}
+
+@keyframes registry-enter {
+  from {
+    opacity: 0;
+    transform: translateY(30px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Decorative corner gradient */
+.e74-registry::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 250px;
+  height: 250px;
+  background: radial-gradient(circle at top right, var(--e74-accent-glow) 0%, transparent 70%);
+  pointer-events: none;
+}
+
+/* Diagonal accent line */
+.e74-registry::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 3px;
+  background: linear-gradient(90deg, var(--e74-accent), #F43F5E 30%, transparent 80%);
+}
+
+.e74-registry-header {
+  margin-bottom: 1.75rem;
+  position: relative;
+}
+
+.e74-registry-title {
+  font-family: var(--e74-font-display) !important;
+  font-size: 1.4rem !important;
+  font-weight: 700 !important;
+  color: var(--e74-text-primary) !important;
+  margin: 0 !important;
+  padding-bottom: 0 !important;
+  letter-spacing: -0.02em !important;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.e74-registry-title::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: linear-gradient(90deg, var(--e74-border), transparent);
+  margin-left: 1rem;
+}
+
+/* Category sections */
+.e74-registry-category {
+  margin-bottom: 1.5rem;
+  animation: category-enter 0.5s ease-out backwards;
+}
+
+.e74-registry-category:last-child {
+  margin-bottom: 0;
+}
+
+.e74-registry-category--base { animation-delay: 0.25s; }
+.e74-registry-category--apps { animation-delay: 0.35s; }
+.e74-registry-category--custom { animation-delay: 0.45s; }
+
+@keyframes category-enter {
+  from {
+    opacity: 0;
+    transform: translateX(-20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+/* Category label - subtle chip */
+.e74-category-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-family: var(--e74-font-display);
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--e74-text-muted);
+  margin-bottom: 0.75rem;
+  padding: 0.35rem 0.75rem;
+  background: var(--e74-bg-surface-alt);
+  border-radius: 50px;
+  border: 1px solid var(--e74-border-subtle);
+}
+
+.e74-category-label .twemoji {
+  width: 0.85rem;
+  height: 0.85rem;
+}
+
+/* Container pills wrapper */
+.e74-container-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+/* Individual container pill */
+.e74-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.65rem 1.2rem;
+  background: var(--e74-bg-primary);
+  border: 1px solid var(--e74-border);
+  border-radius: var(--e74-radius-sm);
+  font-family: var(--e74-font-mono);
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--e74-text-primary);
+  text-decoration: none !important;
+  transition: all var(--e74-transition);
+  position: relative;
+  white-space: nowrap;
+  background-size: 0% 100%;
+}
+
+.e74-pill::before {
+  content: "$ ";
+  color: var(--e74-accent);
+  opacity: 0.6;
+  transition: opacity var(--e74-transition-fast);
+}
+
+/* Category-specific left border accent */
+.e74-pill--base {
+  border-left: 3px solid var(--e74-accent);
+}
+
+.e74-pill--apps {
+  border-left: 3px solid #F43F5E;
+}
+
+.e74-pill--custom {
+  border-left: 3px solid #FB923C;
+}
+
+/* Hover states */
+.e74-pill:hover {
+  transform: translateY(-3px) translateX(3px);
+  box-shadow: var(--e74-shadow), -4px 4px 0 var(--e74-accent-glow);
+  border-color: var(--e74-accent);
+  color: var(--e74-text-primary);
+  text-decoration: none !important;
+}
+
+.e74-pill:hover::before {
+  opacity: 1;
+}
+
+.e74-pill--base:hover {
+  background: linear-gradient(135deg, var(--e74-accent-subtle) 0%, var(--e74-bg-primary) 100%);
+  box-shadow: var(--e74-shadow), -4px 4px 0 rgba(225, 29, 72, 0.15);
+}
+
+.e74-pill--apps:hover {
+  background: linear-gradient(135deg, rgba(244, 63, 94, 0.08) 0%, var(--e74-bg-primary) 100%);
+  box-shadow: var(--e74-shadow), -4px 4px 0 rgba(244, 63, 94, 0.15);
+}
+
+.e74-pill--custom:hover {
+  background: linear-gradient(135deg, rgba(251, 146, 60, 0.08) 0%, var(--e74-bg-primary) 100%);
+  box-shadow: var(--e74-shadow), -4px 4px 0 rgba(251, 146, 60, 0.15);
+}
+
+/* Dark mode enhancements */
+[data-md-color-scheme="slate"] .e74-pill:hover {
+  box-shadow: var(--e74-shadow-lg), -4px 4px 0 var(--e74-accent-glow), 0 0 30px var(--e74-accent-glow);
+}
+
+/* Staggered pill animations */
+.e74-container-pills .e74-pill {
+  animation: pill-enter 0.4s ease-out backwards;
+}
+
+.e74-container-pills .e74-pill:nth-child(1) { animation-delay: 0.3s; }
+.e74-container-pills .e74-pill:nth-child(2) { animation-delay: 0.36s; }
+.e74-container-pills .e74-pill:nth-child(3) { animation-delay: 0.42s; }
+.e74-container-pills .e74-pill:nth-child(4) { animation-delay: 0.48s; }
+.e74-container-pills .e74-pill:nth-child(5) { animation-delay: 0.54s; }
+
+@keyframes pill-enter {
+  from {
+    opacity: 0;
+    transform: translateY(15px) scale(0.9);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+/* =============================================================================
+   13. HOMEPAGE SUPPORT SECTION - OFFSET DESIGN
+   ============================================================================= */
+
+.e74-support {
+  margin-top: 4rem;
+  padding: 2.5rem;
+  background: var(--e74-bg-surface);
+  border: 1px solid var(--e74-border-subtle);
+  border-radius: var(--e74-radius-lg);
+  position: relative;
+  overflow: hidden;
+  animation: fade-in-up 0.6s ease-out 0.4s backwards;
+}
+
+/* Decorative corner accent */
+.e74-support::before {
+  content: "";
+  position: absolute;
+  top: -50px;
+  right: -50px;
+  width: 150px;
+  height: 150px;
+  background: radial-gradient(circle, var(--e74-accent-glow) 0%, transparent 70%);
+  pointer-events: none;
+}
+
+.e74-support h2 {
+  font-family: var(--e74-font-display);
+  font-size: 1.4rem;
+  margin-top: 0;
+  margin-bottom: 1rem;
+  position: relative;
+}
+
+.e74-support > p:first-of-type {
+  color: var(--e74-text-secondary);
+  margin-bottom: 1.5rem;
+  max-width: 500px;
+}
+
+.e74-button-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.e74-btn-sponsor {
+  background: linear-gradient(135deg, var(--e74-accent) 0%, #F43F5E 100%) !important;
+  color: white !important;
+  border: none !important;
+  box-shadow: 0 4px 20px var(--e74-accent-glow);
+  position: relative;
+  overflow: hidden;
+}
+
+.e74-btn-sponsor::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: -100%;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(90deg, transparent, rgba(255,255,255,0.3), transparent);
+  transition: left 0.5s ease;
+}
+
+.e74-btn-sponsor:hover::before {
+  left: 100%;
+}
+
+.e74-btn-sponsor:hover {
+  transform: translateY(-3px) !important;
+  box-shadow: var(--e74-shadow-glow) !important;
+}
+
+.e74-footer-note {
+  margin-top: 3rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--e74-border-subtle);
+  color: var(--e74-text-muted);
+  font-size: 0.85rem;
+  font-family: var(--e74-font-mono);
+  animation: fade-in-up 0.6s ease-out 0.5s backwards;
+}
+
+.e74-footer-note::before {
+  content: "// ";
+  opacity: 0.5;
+}
+
+/* =============================================================================
+   14. TABBED CONTENT
+   ============================================================================= */
+
+.md-typeset .tabbed-labels {
+  border-bottom: 2px solid var(--e74-border-subtle);
+}
+
+.md-typeset .tabbed-labels > label {
+  font-family: var(--e74-font-display);
+  font-weight: 500;
+  color: var(--e74-text-secondary);
+  border-bottom-width: 2px;
+  transition: all var(--e74-transition);
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+}
+
+.md-typeset .tabbed-labels > label:hover {
+  color: var(--e74-text-primary);
+}
+
+.md-typeset .tabbed-labels > label.tabbed-labels__active {
+  color: var(--e74-accent);
+}
+
+.md-typeset .tabbed-labels > input:checked + label {
+  border-color: var(--e74-accent);
+}
+
+/* =============================================================================
+   15. FOOTER
+   ============================================================================= */
+
+.md-footer {
+  background: var(--e74-bg-surface);
+  border-top: 1px solid var(--e74-border-subtle);
+}
+
+.md-footer-meta {
+  background: var(--e74-bg-surface-alt);
+}
+
+/* =============================================================================
+   16. SEARCH
+   ============================================================================= */
+
+.md-search__input {
+  background: var(--e74-bg-surface-alt);
+  border-radius: var(--e74-radius);
+  border: 1px solid transparent;
+  transition: all var(--e74-transition);
+}
+
+.md-search__input:focus {
+  border-color: var(--e74-accent);
+  box-shadow: 0 0 0 3px var(--e74-accent-glow);
+}
+
+.md-search__input::placeholder {
+  color: var(--e74-text-muted);
+  font-family: var(--e74-font-mono);
+  font-size: 0.85rem;
+}
+
+/* =============================================================================
+   17. THEME TOGGLE - PLAYFUL
+   ============================================================================= */
+
+.md-header__button[for="__palette"] {
+  transition: all var(--e74-transition);
+}
+
+.md-header__button[for="__palette"]:hover {
+  transform: rotate(20deg) scale(1.1);
+  color: var(--e74-accent);
+}
+
+/* =============================================================================
+   18. SCROLLBAR
+   ============================================================================= */
+
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+::-webkit-scrollbar-track {
+  background: var(--e74-bg-surface-alt);
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--e74-border);
+  border-radius: 5px;
+  border: 2px solid var(--e74-bg-surface-alt);
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--e74-accent);
+}
+
+/* =============================================================================
+   19. MISC ELEMENTS
+   ============================================================================= */
+
+.donate-button {
+  margin-right: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.heart {
+  color: var(--e74-accent);
+  animation: heartbeat 1.2s ease-in-out infinite;
+  display: inline-block;
+}
+
+@keyframes heartbeat {
+  0%, 100% { transform: scale(1); }
+  25% { transform: scale(1.15); }
+  50% { transform: scale(1); }
+  75% { transform: scale(1.15); }
+}
+
+/* =============================================================================
+   20. MOBILE RESPONSIVENESS
+   ============================================================================= */
+
+@media screen and (max-width: 76.25em) {
+  .e74-hero {
+    padding: 3rem 1.5rem 4rem;
+  }
+
+  .e74-hero h1,
+  .e74-hero-title {
+    font-size: clamp(2rem, 7vw, 3rem) !important;
+  }
+
+  .e74-hero::after {
+    width: 200px;
+    height: 200px;
+    right: 5%;
+  }
+
+  .e74-registry {
+    padding: 1.75rem 2rem;
+  }
+}
+
+@media screen and (max-width: 60em) {
+  .e74-hero::before {
+    display: none;
+  }
+
+  .e74-hero::after {
+    width: 150px;
+    height: 150px;
+    top: 10%;
+    right: -5%;
+  }
+
+  .e74-registry {
+    padding: 1.5rem;
+  }
+
+  .e74-registry::before {
+    width: 150px;
+    height: 150px;
+  }
+
+  .e74-support {
+    padding: 2rem;
+  }
+
+  .e74-button-group {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .e74-button-group .md-button {
+    text-align: center;
+  }
+
+  #tags-table {
+    overflow-x: auto;
+  }
+
+  #tags-table table {
+    min-width: 500px;
+  }
+}
+
+@media screen and (max-width: 44.9375em) {
+  .header-links {
+    display: flex;
+    width: 100%;
+    justify-content: center;
+    margin-right: 0;
+  }
+
+  .e74-hero {
+    padding: 2rem 1rem 3rem;
+    text-align: center;
+  }
+
+  .e74-hero p:not(.e74-hero-subtitle) {
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .e74-registry {
+    padding: 1.25rem;
+  }
+
+  .e74-registry-title {
+    font-size: 1.2rem !important;
+  }
+
+  .e74-registry-title::after {
+    display: none;
+  }
+
+  .e74-category-label {
+    font-size: 0.65rem;
+  }
+
+  .e74-pill {
+    padding: 0.55rem 1rem;
+    font-size: 0.85rem;
+  }
+
+  .e74-container-pills {
+    gap: 0.5rem;
+  }
+
+  .e74-support {
+    text-align: center;
+  }
+
+  .e74-support > p:first-of-type {
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
+/* =============================================================================
+   21. PRINT STYLES
+   ============================================================================= */
+
+@media print {
+  body::before {
+    display: none;
+  }
+
+  .e74-hero {
+    background: none;
+  }
+
+  .e74-hero::before,
+  .e74-hero::after {
+    display: none;
+  }
+
+  .e74-registry {
+    box-shadow: none;
+    border: 1px solid #ddd;
+    break-inside: avoid;
+  }
+
+  .e74-registry::before,
+  .e74-registry::after {
+    display: none;
+  }
+
+  .e74-pill {
+    box-shadow: none;
+    border: 1px solid #ddd;
+  }
+
+  .tag-decoration:hover,
+  .e74-pill:hover {
+    transform: none;
+    box-shadow: none;
+  }
+
+  @keyframes none {
+    from, to { opacity: 1; transform: none; }
+  }
+}
+
+/* =============================================================================
+   22. REDUCED MOTION
+   ============================================================================= */
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+
+  .e74-hero::after {
+    animation: none;
+  }
+
+  .e74-hero-subtitle::after {
+    animation: none;
+    display: none;
+  }
 }

--- a/hweb-content/assets/stylesheets/extra-custom.css
+++ b/hweb-content/assets/stylesheets/extra-custom.css
@@ -283,7 +283,7 @@ body {
   border: 1px solid var(--e74-border-subtle);
   box-shadow: var(--e74-shadow);
   position: relative;
-  overflow: hidden;
+  overflow-x: auto;
 }
 
 .md-typeset pre::before {

--- a/hweb-content/config/mkdocs.yml
+++ b/hweb-content/config/mkdocs.yml
@@ -52,7 +52,23 @@ theme:
   logo: img/engels74.svg
   name: material
   palette:
-    scheme: hotio
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+  font:
+    text: DM Sans
+    code: JetBrains Mono
   custom_dir: overrides
 
 markdown_extensions:

--- a/hweb-content/docs/index.md
+++ b/hweb-content/docs/index.md
@@ -25,7 +25,7 @@ Revived projects, enhanced images, and original creations — all with Docker CL
 
 <div class="e74-registry-category e74-registry-category--base" markdown>
 
-<span class="e74-category-label">:octicons-server-16: Foundation</span>
+**:octicons-server-16: Foundation**{ .e74-category-label }
 
 <div class="e74-container-pills" markdown>
 
@@ -37,7 +37,7 @@ Revived projects, enhanced images, and original creations — all with Docker CL
 
 <div class="e74-registry-category e74-registry-category--apps" markdown>
 
-<span class="e74-category-label">:octicons-repo-forked-16: Hotio Forks</span>
+**:octicons-repo-forked-16: Hotio Forks**{ .e74-category-label }
 
 <div class="e74-container-pills" markdown>
 
@@ -53,7 +53,7 @@ Revived projects, enhanced images, and original creations — all with Docker CL
 
 <div class="e74-registry-category e74-registry-category--custom" markdown>
 
-<span class="e74-category-label">:octicons-code-16: Original Projects</span>
+**:octicons-code-16: Original Projects**{ .e74-category-label }
 
 <div class="e74-container-pills" markdown>
 

--- a/hweb-content/docs/index.md
+++ b/hweb-content/docs/index.md
@@ -1,40 +1,91 @@
 ---
 hide:
   - navigation
+  - toc
 ---
 
-## Welcome
+<div class="e74-hero" markdown>
 
-This is a fork of hotio's [official website](https://hotio.dev), repurposed to document my collection of Docker containers:
+# :material-docker: engels74.net { .e74-hero-title }
 
-- **Revived containers** — forks of hotio's deprecated projects, like qflood
-- **Modified containers** — forks of hotio's images with personal additions, such as Caddy, qBittorrent with built-in themes, and SABnzbd with ffmpeg
-- **Original projects** — documentation for my own dockerized software (obzorarr, tgraph-bot, etc)
+**Docker containers for the media server enthusiast**
+{ .e74-hero-subtitle }
 
-All images come with Docker CLI and Compose examples.
+Revived projects, enhanced images, and original creations — all with Docker CLI and Compose examples.
 
-If you have any questions, feel free to open an issue on the relevant GitHub repository.
+</div>
 
-## Donations
+<div class="e74-registry" markdown>
 
-Show some (monetary) love for hotio - he definitely deserves it! :octicons-heart-fill-24:{: .heart }
+<div class="e74-registry-header" markdown>
 
-[:material-github: GitHub Sponsors](https://github.com/sponsors/mrhotio){: .md-button target=_blank rel="noopener" .donate-button }
-[:fontawesome-solid-money-bill-wave: Open Collective](https://opencollective.com/hotio_collective/donate?interval=month&amount=10){: .md-button target=_blank rel="noopener" .donate-button }
-[:material-bitcoin: Bitcoin](https://bitcoinblockexplorers.com/address/bc1q6zkemu2lacynfg6d6x70l0da0mdpf06pn83jm5){: .md-button target=_blank rel="noopener" .donate-button }
+## :octicons-container-16: Container Registry { .e74-registry-title }
 
-## Affiliate Links
+</div>
 
-If you need a VPN, you can use hotio's affiliate links:
+<div class="e74-registry-category e74-registry-category--base" markdown>
 
-<img src="https://go.getproton.me/aff_i?offer_id=26&aff_id=7223" width="0" height="0" style="position:absolute;visibility:hidden;" border="0" />
-<a href="https://hotio.dev/protonvpn" target="_blank" rel="noopener">
-  <img id="vpnbanner" src="/img/protonvpn@2x.png" alt="ProtonVPN" width="320" height="50">
-</a>
-<a href="https://hotio.dev/pia" target="_blank" rel="noopener">
-  <img id="vpnbanner" src="/img/piavpn728x90.png" alt="PiaVPN" width="404" height="50">
-</a>
+<span class="e74-category-label">:octicons-server-16: Foundation</span>
 
-## Support
+<div class="e74-container-pills" markdown>
 
-For support, please create an issue on the GitHub repository for the specific container you need help with.
+[base-image](containers/base-image.md){ .e74-pill .e74-pill--base }
+
+</div>
+
+</div>
+
+<div class="e74-registry-category e74-registry-category--apps" markdown>
+
+<span class="e74-category-label">:octicons-repo-forked-16: Hotio Forks</span>
+
+<div class="e74-container-pills" markdown>
+
+[Caddy](containers/caddy.md){ .e74-pill .e74-pill--apps }
+[Overseerr](containers/overseerr-anime.md){ .e74-pill .e74-pill--apps }
+[qBittorrent](containers/qbittorrent.md){ .e74-pill .e74-pill--apps }
+[qFlood](containers/qflood.md){ .e74-pill .e74-pill--apps }
+[SABnzbd](containers/sabnzbd.md){ .e74-pill .e74-pill--apps }
+
+</div>
+
+</div>
+
+<div class="e74-registry-category e74-registry-category--custom" markdown>
+
+<span class="e74-category-label">:octicons-code-16: Original Projects</span>
+
+<div class="e74-container-pills" markdown>
+
+[Obzorarr](containers/obzorarr.md){ .e74-pill .e74-pill--custom }
+[tgraph-bot](containers/tgraph-bot.md){ .e74-pill .e74-pill--custom }
+
+</div>
+
+</div>
+
+</div>
+
+<div class="e74-support" markdown>
+
+## :octicons-heart-16: Support
+
+This project builds on [hotio's](https://hotio.dev) excellent work. Consider supporting hotio:
+
+<div class="e74-button-group" markdown>
+
+[:material-github: GitHub Sponsors](https://github.com/sponsors/mrhotio){ .md-button .e74-btn-sponsor target=_blank rel="noopener" }
+[:fontawesome-solid-money-bill-wave: Open Collective](https://opencollective.com/hotio_collective/donate?interval=month&amount=10){ .md-button target=_blank rel="noopener" }
+
+</div>
+
+**Need a VPN?** Use hotio's affiliate links:
+[ProtonVPN](https://hotio.dev/protonvpn){ target=_blank rel="noopener" } · [PIA](https://hotio.dev/pia){ target=_blank rel="noopener" }
+
+</div>
+
+<div class="e74-footer-note" markdown>
+
+For support, open an issue on the relevant [GitHub repository](https://github.com/engels74){ target=_blank rel="noopener" }.
+
+</div>

--- a/hweb-content/docs/overrides/main.html
+++ b/hweb-content/docs/overrides/main.html
@@ -1,8 +1,15 @@
 {% extends "base.html" %}
 {% block extrahead %}
-  <meta name="theme-color" content="#3c3f44ff">
-  <link rel="preconnect" href="https://fonts.gstatic.com">
-  <link href="https://fonts.googleapis.com/css2?family=Architects+Daughter&display=swap" rel="stylesheet">
+  <!-- Dynamic theme color based on scheme -->
+  <meta name="theme-color" content="#FFFBFA" media="(prefers-color-scheme: light)">
+  <meta name="theme-color" content="#0C0A09" media="(prefers-color-scheme: dark)">
+
+  <!-- Fonts: Outfit (display), DM Sans (body), JetBrains Mono (code) -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Outfit:wght@500;600;700&display=swap" rel="stylesheet">
+
+  <!-- Favicon and Apple icons -->
   <link rel="icon" type="image/svg+xml" href="/img/engels74.svg" />
   <link rel="apple-touch-icon" href="/img/engels74.svg" />
   <meta name="apple-mobile-web-app-title" content="engels74.net" />

--- a/hweb-content/docs/overrides/main.html
+++ b/hweb-content/docs/overrides/main.html
@@ -2,7 +2,7 @@
 {% block extrahead %}
   <!-- Dynamic theme color based on scheme -->
   <meta name="theme-color" content="#FFFBFA" media="(prefers-color-scheme: light)">
-  <meta name="theme-color" content="#0C0A09" media="(prefers-color-scheme: dark)">
+  <meta name="theme-color" content="#0A0908" media="(prefers-color-scheme: dark)">
 
   <!-- Fonts: Outfit (display), DM Sans (body), JetBrains Mono (code) -->
   <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
This commit consolidates the UI redesign branch with the following changes:

Homepage improvements:
- Consolidate containers into unified registry panel
- Alphabetize container lists for easier navigation
- Rename 'Enhanced Apps' to 'Hotio Forks'

Styling:
- Add bold crimson terminal aesthetic with dark/light mode support
- Increase container page icon size (90px → 120px)